### PR TITLE
fix(circle ci): have circleCI update permissions itself

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,15 @@ jobs:
           name: Print working directory.
           command: 'pwd'
       - run:
+          name: List files in bash-scripts directory pre-chmod
+          command: ls -la ./bash-scripts
+      - run:
+          name: Set execute permissions for deploy.sh
+          command: chmod +x ./bash-scripts/deploy.sh
+      - run:
+          name: List files in bash-scripts directory post-chmod
+          command: ls -la ./bash-scripts
+      - run:
           name: Run deploy script.
           command: 'sh ./bash-scripts/deploy.sh'
 workflows:


### PR DESCRIPTION
# Pull Request

## Description

Explicitly have the permissions set internally.

## Related Issues

- #12
- #13
- #14
- #15

## Screenshots / GIFs (if applicable)

[Include any relevant screenshots or GIFs to visually demonstrate the changes]

## Checklist

- [ ] I have read the "Contributing" page on confluence.
- [ ] All local checks pass on my machine.
- [ ] I have adhered to the definition of done within the scope of.
- [ ] I have updated the documentation accordingly.
- [ ] I have left a comment self-reviewing my PR.

## Additional Notes

[Add any additional context or notes for reviewers]
