### PR TITLE
Feat/sbyu 136/may fishers cleanup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - SBYU-135: Fishers Cleanup tab
+- SBYU-136: Fishers Cleanup May update
 
 ## [1.1.0] - 2025-01-10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strommen-byu-app",
-  "version": "1.1.0-dev-sbyu-135",
+  "version": "1.1.0-dev-sbyu-136",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strommen-byu-app",
-      "version": "1.1.0-dev-sbyu-135",
+      "version": "1.1.0-dev-sbyu-136",
       "dependencies": {
         "archiver": "^7.0.1",
         "crypto-js": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strommen-byu-app",
-  "version": "1.1.0-dev-sbyu-135",
+  "version": "1.1.0-dev-sbyu-136",
   "private": true,
   "homepage": "http://strommenbyu.com",
   "scripts": {

--- a/src/components/fishers.jsx
+++ b/src/components/fishers.jsx
@@ -29,21 +29,6 @@ function Fishers() {
               Meetinghouse Cleanup - Feb 1 (Saturday)
             </a>
           </li>
-          <li className="fishers-list-item">
-            <a href="https://www.signupgenius.com/go/60B0449AFAA29ABFD0-54467971-meetinghouse" target="_blank" rel="noreferrer" className="fishers-link">
-              Meetinghouse Cleanup - Feb 8 (Saturday)
-            </a>
-          </li>
-          <li className="fishers-list-item">
-            <a href="https://www.signupgenius.com/go/60B0449AFAA29ABFD0-54467969-meetinghouse" target="_blank" rel="noreferrer" className="fishers-link">
-              Meetinghouse Cleanup - Feb 15 (Saturday)
-            </a>
-          </li>
-          <li className="fishers-list-item">
-            <a href="https://www.signupgenius.com/go/60B0449AFAA29ABFD0-54467992-meetinghouse" target="_blank" rel="noreferrer" className="fishers-link">
-              Meetinghouse Cleanup - Feb 22 (Saturday)
-            </a>
-          </li>
         </ul>
       </div>
     </div>

--- a/src/components/fishers.jsx
+++ b/src/components/fishers.jsx
@@ -25,8 +25,8 @@ function Fishers() {
         </p>
         <ul className="fishers-list">
           <li className="fishers-list-item">
-            <a href="https://www.signupgenius.com/go/60B0449AFAA29ABFD0-54467937-meetinghouse" target="_blank" rel="noreferrer" className="fishers-link">
-              Meetinghouse Cleanup - Feb 1 (Saturday)
+            <a href="https://www.signupgenius.com/go/60B0449AFAA29ABFD0-56273712-meetinghouse#/" target="_blank" rel="noreferrer" className="fishers-link">
+              Meetinghouse Cleanup - SignUp
             </a>
           </li>
         </ul>

--- a/src/components/fishers.jsx
+++ b/src/components/fishers.jsx
@@ -11,12 +11,12 @@ function Fishers() {
       />
       <div className="page-content">
         <p className="paragraph-1">
-          It is time for our 2nd Ward families to sign up
-          for our meetinghouse cleaning days in February.
-          I&apos;ve prepared a SignUp page for each Saturday in February.
+          It is time for our 2nd Ward families to sign up for our meetinghouse cleaning days.
+          I&apos;ve prepared a SignUp page for each Saturday for our assignment.
           Please select 1 or 2 days for your family to participate in cleaning the church.
-          I feel that using this approach lets you choose your timing according
-          to your schedule and let&apos;s you know which task you will perform that day.
+          I feel that using this approach lets you choose your timing according to your schedule
+          and lets you know which task you will perform that day.
+          Our ward is assigned to clean the church in February, May, August, and November.
           <br />
           <br />
           Thanks,


### PR DESCRIPTION
# Pull Request

## Description

This PR generalizes StrommenByu.com/fishers to display text suitable for the whole year. Links have been reduced to a single calendar-signup approcah.

## Related Issues

- #39 

## Screenshots / GIFs (if applicable)

<details>
<summary>Updated Fishers Page</summary>

![image](https://github.com/user-attachments/assets/f1b66dc3-f5ae-493d-8c8f-c644acff56db)
</details>

## Checklist

- [x] I have read the "Contributing" page on confluence.
- [x] All local checks pass on my machine.
- [x] I have adhered to the definition of done within the scope of this work.
- [x] I have updated Confluence documentation as needed.
- [x] I have updated the changelog.
- [x] I have left a comment self-reviewing my PR.

## Additional Notes

[Add any additional context or notes for reviewers]
